### PR TITLE
fix(websockets): Initialise io_loop in multi-worker environments

### DIFF
--- a/bokeh_django/consumers.py
+++ b/bokeh_django/consumers.py
@@ -223,21 +223,21 @@ class WSConsumer(AsyncWebsocketConsumer, ConsumerHelper):
 
         subprotocols = self.scope["subprotocols"]
         if len(subprotocols) != 2 or subprotocols[0] != 'bokeh':
-            self.close()
+            await self.close()
             raise RuntimeError("Subprotocol header is not 'bokeh'")
 
         token = subprotocols[1]
         if token is None:
-            self.close()
+            await self.close()
             raise RuntimeError("No token received in subprotocol header")
 
         now = calendar.timegm(dt.datetime.now(dt.UTC).utctimetuple())
         payload = get_token_payload(token)
         if 'session_expiry' not in payload:
-            self.close()
+            await self.close()
             raise RuntimeError("Session expiry has not been provided")
         elif now >= payload['session_expiry']:
-            self.close()
+            await self.close()
             raise RuntimeError("Token is expired.")
         elif not check_token_signature(token,
                                        signed=False,
@@ -292,7 +292,7 @@ class WSConsumer(AsyncWebsocketConsumer, ConsumerHelper):
 
         except Exception as e:
             log.error("Could not create new server session, reason: %s", e)
-            self.close()
+            await self.close()
             raise e
 
         msg = self.connection.protocol.create('ACK')

--- a/bokeh_django/consumers.py
+++ b/bokeh_django/consumers.py
@@ -231,7 +231,7 @@ class WSConsumer(AsyncWebsocketConsumer, ConsumerHelper):
             self.close()
             raise RuntimeError("No token received in subprotocol header")
 
-        now = calendar.timegm(dt.datetime.utcnow().utctimetuple())
+        now = calendar.timegm(dt.datetime.now(dt.UTC).utctimetuple())
         payload = get_token_payload(token)
         if 'session_expiry' not in payload:
             self.close()


### PR DESCRIPTION
## Problem Addressed
This PR addresses the issue where WebSocket connections frequently fail when running a Django application with Bokeh integration using multiple Gunicorn workers. In multi-worker environments, there was only a 1/n chance (where n is the number of workers) that the WebSocket connection would succeed.

## Solution
The solution implements a more robust approach to io_loop initialisation by:

1. Explicitly setting the io_loop using `IOLoop.current()` if it doesn't exist
3. Ensuring the io_loop is set before attempting session creation
4. Adding defensive coding in the disconnect method

This change removes the worker affinity requirement, allowing any worker to successfully handle WebSocket connections regardless of which worker handled the initial HTTP request.

## Changes Made
- Modified `WSConsumer.application_context` to initialise the `io_loop` rather than raising an error
- Ensured proper io_loop initialisation before session creation
- Misc: Fixed a deprecation and added `await` to some un-awaited coroutines

## Testing
Tested with Gunicorn running with 4 Uvicorn workers, confirming:
- Before fix: ~25% success rate for Bokeh autoload app loading
- After fix: 100% success rate for Bokeh autoload app loading

Closes #15
